### PR TITLE
Fix typo in Modbuc TCP/IP docs heading

### DIFF
--- a/go-eCharger Modbus TCP API v1 DE.md
+++ b/go-eCharger Modbus TCP API v1 DE.md
@@ -1,4 +1,4 @@
-# GO-E Charger Modbus TCP/IP Dokumentation Detusch
+# GO-E Charger Modbus TCP/IP Dokumentation Deutsch
 
 | Version | Date       | Author      | Description     |
 | ------- | ---------- | ----------- | --------------- |


### PR DESCRIPTION
Fix typo: Detusch -> Deutsch